### PR TITLE
Use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/src/ijulia_integration.jl
+++ b/src/ijulia_integration.jl
@@ -14,7 +14,7 @@ import Base.writemime
 #   => libraries are loaded externally in the `require.config`
 
 # function jslibpath(url...)
-#   libpath = Pkg.dir("VegaLite", "assets", "bower_components", url...)
+#   libpath = joinpath(dirname(@__FILE__), "..", "assets", "bower_components", url...)
 #   replace(libpath, "\\", "/")  # for windows...
 # end
 # // d3: "$(jslibpath("d3","d3.min.js"))",

--- a/src/render.jl
+++ b/src/render.jl
@@ -1,5 +1,5 @@
 
-asset(url...) = @compat readstring(Pkg.dir("VegaLite", "assets", "bower_components", url...))
+asset(url...) = @compat readstring(joinpath(dirname(@__FILE__), "..", "assets", "bower_components", url...))
 
 #Vega Scaffold: https://github.com/vega/vega/wiki/Runtime
 function writehtml(io::IO, v::VegaLiteVis; title="Vega.jl Visualization")
@@ -153,7 +153,7 @@ end
 # end
 
 # function jslibpath(url...)
-#   libpath = Pkg.dir("VegaLite", "assets", "bower_components", url...)
+#   libpath = joinpath(dirname(@__FILE__), "..", "assets", "bower_components", url...)
 #   replace(libpath, "\\", "/")  # for windows...
 # end
 #


### PR DESCRIPTION
This allows installing the package elsewhere.

Add testing against 0.5 to Travis - this runs the most
recent release candidate now, release once final tags are done

see https://github.com/johnmyleswhite/Vega.jl/pull/144 for a warning about conditional
dependencies and precompilation that also applies here