### PR TITLE
Use NodeJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docs/build/
 docs/site/
+deps/node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: julia
+sudo: required
 os:
   - linux
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,12 @@ addons:
             - xvfb
             - xauth        
             - libgtk-3-0
+            - libcairo2-dev
+            - libjpeg8-dev
+            - libpango1.0-dev
+            - libgif-dev
+            - build-essential
+            - g++
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - if [[ `uname` = "Linux" ]]; then TESTCMD="xvfb-run julia"; else TESTCMD="julia"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,6 @@ addons:
             - xvfb
             - xauth        
             - libgtk-3-0
-            - libcairo2-dev
-            - libjpeg8-dev
-            - libpango1.0-dev
-            - libgif-dev
-            - build-essential
-            - g++
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - if [[ `uname` = "Linux" ]]; then TESTCMD="xvfb-run julia"; else TESTCMD="julia"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,13 @@ notifications:
 addons:
     apt:
         packages:
+            - xvfb
+            - xauth        
             - libgtk-3-0
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("VegaLite"); Pkg.test("VegaLite"; coverage=true)'
+  - if [[ `uname` = "Linux" ]]; then TESTCMD="xvfb-run julia"; else TESTCMD="julia"; fi
+  - $TESTCMD --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("VegaLite"); Pkg.test("VegaLite"; coverage=true)'
 after_success:
   - julia -e 'cd(Pkg.dir("VegaLite")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
   - julia -e 'Pkg.add("Documenter")'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,13 @@ os:
 julia:
   - 0.4
   - 0.5
-  - nightly
+  - 0.6
 notifications:
   email: false
+addons:
+    apt:
+        packages:
+            - libgtk-3-0
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("VegaLite"); Pkg.test("VegaLite"; coverage=true)'

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,5 @@ Compat 0.8
 JSON
 Requires
 NodeJS
+Cairo
+Rsvg

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.4
 Compat 0.8
 JSON
 Requires
+NodeJS

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.4
-Compat 0.8
+Compat 0.9.1
 JSON
 Requires
 NodeJS

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,3 @@
+using NodeJS
+
+run(Cmd(`$(npm_cmd()) install`, dir=@__DIR__))

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,3 +1,4 @@
 using NodeJS
+using Compat
 
 run(Cmd(`$(npm_cmd()) install`, dir=@__DIR__))

--- a/deps/package.json
+++ b/deps/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "vegalitejl",
+  "version": "1.0.0",
+  "dependencies": {
+    "rw": "^1.3.3",
+    "vega": "^3.0.0-beta.32",    
+    "vega-lite": "^2.0.0-beta.3",
+    "vega-embed": "^3.0.0-beta.15"
+  }
+}

--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -2,7 +2,7 @@ VERSION >= v"0.4" && __precompile__()
 
 module VegaLite
 
-using JSON, Compat, Requires
+using JSON, Compat, Requires, NodeJS, Cairo, Rsvg
 
 import Base: +, *, scale, show
 
@@ -43,6 +43,7 @@ include("config.jl")
 include("data_values.jl")
 include("mark.jl")
 include("encoding.jl")
+include("conversions.jl")
 
 ### Integration with Escher (Escher does not seem to work in 0.5)
 # include("escher_integration.jl")

--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -33,6 +33,8 @@ export encoding_x_quant, encoding_x_temp, encoding_x_ord, encoding_x_nominal,
     encoding_row_quant, encoding_row_temp, encoding_row_ord, encoding_row_nominal,
     encoding_column_quant, encoding_column_temp, encoding_column_ord, encoding_column_nominal
 
+export savefig
+
 
 include("utils.jl")
 include("render.jl")
@@ -43,7 +45,8 @@ include("config.jl")
 include("data_values.jl")
 include("mark.jl")
 include("encoding.jl")
-include("conversions.jl")
+include("io.jl")
+include("show.jl")
 
 ### Integration with Escher (Escher does not seem to work in 0.5)
 # include("escher_integration.jl")

--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -4,7 +4,9 @@ module VegaLite
 
 using JSON, Compat, Requires, NodeJS, Cairo, Rsvg
 
-import Base: +, *, scale, show
+import Base: +, *, scale
+
+@compat import Base.show
 
 export VegaLiteVis, scale, axis, legend
 

--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -33,7 +33,7 @@ export encoding_x_quant, encoding_x_temp, encoding_x_ord, encoding_x_nominal,
     encoding_row_quant, encoding_row_temp, encoding_row_ord, encoding_row_nominal,
     encoding_column_quant, encoding_column_temp, encoding_column_ord, encoding_column_nominal
 
-export savefig
+export savefig, svg, png, pdf, eps
 
 
 include("utils.jl")

--- a/src/compilesvg.js
+++ b/src/compilesvg.js
@@ -1,0 +1,38 @@
+'use strict';
+
+// import required libraries
+var fs = require('fs'),
+    path = require('path'),
+    vl = require('../deps/node_modules/vega-lite'),
+    rw = require('../deps/node_modules/rw'),
+    vega = require('../deps/node_modules/vega');
+
+// set baseURL if provided on command line
+var base = 'file://' + process.cwd() + path.sep;
+
+// load spec, compile vg spec
+rw.readFile('/dev/stdin', 'utf8', function(err, text) {
+  if (err) throw err;
+  var spec = JSON.parse(text);
+  compile(spec);
+});
+
+function compile(vlSpec) {
+  var result =  vl.compile(vlSpec);
+  // TODO: deal with error
+  var vgSpec = result.spec;
+
+  var view = new vega.View(vega.parse(vgSpec), {
+      loader: vega.loader({baseURL: base}),
+      logLevel: vega.Warn,
+      renderer: 'none'
+    })
+    .initialize()
+    .toSVG()
+    .then(function(svg) { writeSVG(svg); })
+    .catch(function(err) { console.error(err); });
+}
+
+function writeSVG(svg) {
+  rw.writeFile('/dev/stdout', svg, function(err) { if (err) throw err; });
+}

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -1,0 +1,47 @@
+function convert_to_svg(v::VegaLiteVis)
+    data = JSON.json(v.vis)
+    script_path = joinpath(@__DIR__, "compilesvg.js")
+    p_out, p_in, p = readandwrite(`$(nodejs_cmd()) $script_path`)
+    write(p_in, data)
+    flush(p_in)
+    close(p_in)
+    res = readstring(p_out)
+    close(p_out)
+    return res
+end
+
+function savefig_svg(filename::AbstractString, v::VegaLiteVis)
+    svgHeader = """
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+"""
+
+    open(filename, "w") do f
+        print(f, svgHeader)
+        print(f, convert_to_svg(v))
+    end
+end
+
+function savefig_pdf(filename::AbstractString, v::VegaLiteVis)
+    svgstring = convert_to_svg(v)
+
+    r = Rsvg.handle_new_from_data(svgstring)
+    d = Rsvg.handle_get_dimensions(r)
+
+    cs = Cairo.CairoPDFSurface(filename, d.width,d.height)
+    c = Cairo.CairoContext(cs)
+    Rsvg.handle_render_cairo(c,r)
+    finish(cs)
+end
+
+function savefig_png(filename::AbstractString, v::VegaLiteVis)
+    svgstring = convert_to_svg(v)
+    
+    r = Rsvg.handle_new_from_data(svgstring)
+    d = Rsvg.handle_get_dimensions(r)
+
+    cs = Cairo.CairoImageSurface(d.width,d.height,Cairo.FORMAT_ARGB32)
+    c = Cairo.CairoContext(cs)
+    Rsvg.handle_render_cairo(c,r)
+    Cairo.write_to_png(cs,filename)
+end

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,3 +1,9 @@
+function savefig(filename::AbstractString, mime::AbstractString, v::VegaLiteVis)
+    open(filename, "w") do f
+        show(f, mime, v)
+    end        
+end
+
 function savefig(filename::AbstractString, v::VegaLiteVis)
     file_ext = lowercase(splitext(filename)[2])
     if file_ext == ".svg"
@@ -14,7 +20,21 @@ function savefig(filename::AbstractString, v::VegaLiteVis)
         throw(ArgumentError("Unknown file type."))
     end
 
-    open(filename, "w") do f
-        show(f, mime, v)
-    end    
+    savefig(filename, mime, v)
+end
+
+function svg(filename::AbstractString, v::VegaLiteVis)
+    savefig(filename, "image/svg+xml", v)
+end
+
+function pdf(filename::AbstractString, v::VegaLiteVis)
+    savefig(filename, "application/pdf", v)
+end
+
+function png(filename::AbstractString, v::VegaLiteVis)
+    savefig(filename, "image/png", v)
+end
+
+function eps(filename::AbstractString, v::VegaLiteVis)
+    savefig(filename, "application/eps", v)
 end

--- a/src/io.jl
+++ b/src/io.jl
@@ -5,7 +5,11 @@ function savefig(filename::AbstractString, v::VegaLiteVis)
     elseif file_ext == ".pdf"
         mime = "application/pdf"
     elseif file_ext == ".png"
-        mime = "image/png"
+        mime = "image/png"        
+    elseif file_ext == ".eps"
+        mime = "application/eps"
+    # elseif file_ext == ".ps"
+    #     mime = "application/postscript"
     else
         throw(ArgumentError("Unknown file type."))
     end

--- a/src/io.jl
+++ b/src/io.jl
@@ -4,6 +4,12 @@ function savefig(filename::AbstractString, mime::AbstractString, v::VegaLiteVis)
     end        
 end
 
+"""
+    savefig(filename::AbstractString, v::VegaLiteVis)
+
+Save the plot ``v`` as a file with name ``filename``. The file format
+will be picked based on the extension of the filename.
+"""
 function savefig(filename::AbstractString, v::VegaLiteVis)
     file_ext = lowercase(splitext(filename)[2])
     if file_ext == ".svg"
@@ -23,18 +29,38 @@ function savefig(filename::AbstractString, v::VegaLiteVis)
     savefig(filename, mime, v)
 end
 
+"""
+    svg(filename::AbstractString, v::VegaLiteVis)
+
+Save the plot ``v``` as a svg file with name ``filname``.
+"""
 function svg(filename::AbstractString, v::VegaLiteVis)
     savefig(filename, "image/svg+xml", v)
 end
 
+"""
+    pdf(filename::AbstractString, v::VegaLiteVis)
+
+Save the plot ``v``` as a pdf file with name ``filname``.
+"""
 function pdf(filename::AbstractString, v::VegaLiteVis)
     savefig(filename, "application/pdf", v)
 end
 
+"""
+    png(filename::AbstractString, v::VegaLiteVis)
+
+Save the plot ``v``` as a png file with name ``filname``.
+"""
 function png(filename::AbstractString, v::VegaLiteVis)
     savefig(filename, "image/png", v)
 end
 
+"""
+    eps(filename::AbstractString, v::VegaLiteVis)
+
+Save the plot ``v``` as a eps file with name ``filname``.
+"""
 function eps(filename::AbstractString, v::VegaLiteVis)
     savefig(filename, "application/eps", v)
 end

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,0 +1,16 @@
+function savefig(filename::AbstractString, v::VegaLiteVis)
+    file_ext = lowercase(splitext(filename)[2])
+    if file_ext == ".svg"
+        mime = "image/svg+xml"
+    elseif file_ext == ".pdf"
+        mime = "application/pdf"
+    elseif file_ext == ".png"
+        mime = "image/png"
+    else
+        throw(ArgumentError("Unknown file type."))
+    end
+
+    open(filename, "w") do f
+        show(f, mime, v)
+    end    
+end

--- a/src/render.jl
+++ b/src/render.jl
@@ -4,7 +4,7 @@
 #
 ######################################################################
 
-asset(url...) = @compat readstring(joinpath(dirname(@__FILE__), "..", "assets", "bower_components", url...))
+asset(url...) = @compat readstring(joinpath(dirname(@__FILE__), "..", "deps", "node_modules", url...))
 
 #Vega Scaffold: https://github.com/vega/vega/wiki/Runtime
 function writehtml(io::IO, v::VegaLiteVis; title="VegaLite plot")
@@ -17,9 +17,9 @@ function writehtml(io::IO, v::VegaLiteVis; title="VegaLite plot")
       <title>$title</title>
       <meta charset="UTF-8">
       <script>$(asset("d3","d3.min.js"))</script>
-      <script>$(asset("vega", "vega.js"))</script>
-      <script>$(asset("vega-lite", "vega-lite.js"))</script>
-      <script>$(asset("vega-embed", "vega-embed.js"))</script>
+      <script>$(asset("vega", "build", "vega.min.js"))</script>
+      <script>$(asset("vega-lite", "build", "vega-lite.min.js"))</script>
+      <script>$(asset("vega-embed", "vega-embed.min.js"))</script>
     </head>
     <body>
       <div id="$divid"></div>
@@ -36,17 +36,13 @@ function writehtml(io::IO, v::VegaLiteVis; title="VegaLite plot")
 
     <script type="text/javascript">
 
-      var embedSpec = {
+      var opt = {
         mode: "vega-lite",
         renderer: "$(SVG ? "svg" : "canvas")",
-        actions: $SAVE_BUTTONS,
-        spec: $(JSON.json(v.vis))
+        actions: $SAVE_BUTTONS
       }
-
-      vg.embed("#$divid", embedSpec, function(error, result) {
-        result.view.renderer("svg")
-      });
-
+      var spec = $(JSON.json(v.vis))
+      vega.embed('#$divid', spec, opt);    
     </script>
 
   </html>

--- a/src/show.jl
+++ b/src/show.jl
@@ -10,7 +10,7 @@ function convert_to_svg(v::VegaLiteVis)
     return res
 end
 
-function Base.show(io::IO, m::MIME"image/svg+xml", v::VegaLiteVis)
+@compat function Base.show(io::IO, m::MIME"image/svg+xml", v::VegaLiteVis)
    svgHeader = """
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
@@ -20,7 +20,7 @@ function Base.show(io::IO, m::MIME"image/svg+xml", v::VegaLiteVis)
     print(io, convert_to_svg(v))
 end
 
-function Base.show(io::IO, m::MIME"application/pdf", v::VegaLiteVis)
+@compat function Base.show(io::IO, m::MIME"application/pdf", v::VegaLiteVis)
     svgstring = convert_to_svg(v)
 
     r = Rsvg.handle_new_from_data(svgstring)
@@ -32,7 +32,7 @@ function Base.show(io::IO, m::MIME"application/pdf", v::VegaLiteVis)
     finish(cs)
 end
 
-function Base.show(io::IO, m::MIME"application/eps", v::VegaLiteVis)
+@compat function Base.show(io::IO, m::MIME"application/eps", v::VegaLiteVis)
     svgstring = convert_to_svg(v)
 
     r = Rsvg.handle_new_from_data(svgstring)
@@ -56,7 +56,7 @@ end
 #     finish(cs)
 # end
 
-function Base.show(io::IO, m::MIME"image/png", v::VegaLiteVis)
+@compat function Base.show(io::IO, m::MIME"image/png", v::VegaLiteVis)
     svgstring = convert_to_svg(v)
     
     r = Rsvg.handle_new_from_data(svgstring)

--- a/src/show.jl
+++ b/src/show.jl
@@ -10,31 +10,29 @@ function convert_to_svg(v::VegaLiteVis)
     return res
 end
 
-function savefig_svg(filename::AbstractString, v::VegaLiteVis)
-    svgHeader = """
+function Base.show(io::IO, m::MIME"image/svg+xml", v::VegaLiteVis)
+   svgHeader = """
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 """
 
-    open(filename, "w") do f
-        print(f, svgHeader)
-        print(f, convert_to_svg(v))
-    end
+    print(io, svgHeader)
+    print(io, convert_to_svg(v))
 end
 
-function savefig_pdf(filename::AbstractString, v::VegaLiteVis)
+function Base.show(io::IO, m::MIME"application/pdf", v::VegaLiteVis)
     svgstring = convert_to_svg(v)
 
     r = Rsvg.handle_new_from_data(svgstring)
     d = Rsvg.handle_get_dimensions(r)
 
-    cs = Cairo.CairoPDFSurface(filename, d.width,d.height)
+    cs = Cairo.CairoPDFSurface(io, d.width,d.height)
     c = Cairo.CairoContext(cs)
     Rsvg.handle_render_cairo(c,r)
     finish(cs)
 end
 
-function savefig_png(filename::AbstractString, v::VegaLiteVis)
+function Base.show(io::IO, m::MIME"image/png", v::VegaLiteVis)
     svgstring = convert_to_svg(v)
     
     r = Rsvg.handle_new_from_data(svgstring)
@@ -43,5 +41,5 @@ function savefig_png(filename::AbstractString, v::VegaLiteVis)
     cs = Cairo.CairoImageSurface(d.width,d.height,Cairo.FORMAT_ARGB32)
     c = Cairo.CairoContext(cs)
     Rsvg.handle_render_cairo(c,r)
-    Cairo.write_to_png(cs,filename)
+    Cairo.write_to_png(cs,io)
 end

--- a/src/show.jl
+++ b/src/show.jl
@@ -32,6 +32,30 @@ function Base.show(io::IO, m::MIME"application/pdf", v::VegaLiteVis)
     finish(cs)
 end
 
+function Base.show(io::IO, m::MIME"application/eps", v::VegaLiteVis)
+    svgstring = convert_to_svg(v)
+
+    r = Rsvg.handle_new_from_data(svgstring)
+    d = Rsvg.handle_get_dimensions(r)
+
+    cs = Cairo.CairoEPSSurface(io, d.width,d.height)
+    c = Cairo.CairoContext(cs)
+    Rsvg.handle_render_cairo(c,r)
+    finish(cs)
+end
+
+# function Base.show(io::IO, m::MIME"application/postscript", v::VegaLiteVis)
+#     svgstring = convert_to_svg(v)
+
+#     r = Rsvg.handle_new_from_data(svgstring)
+#     d = Rsvg.handle_get_dimensions(r)
+
+#     cs = Cairo.CairoPSSurface(io, d.width,d.height)
+#     c = Cairo.CairoContext(cs)
+#     Rsvg.handle_render_cairo(c,r)
+#     finish(cs)
+# end
+
 function Base.show(io::IO, m::MIME"image/png", v::VegaLiteVis)
     svgstring = convert_to_svg(v)
     

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,7 +42,6 @@ mpg = dataset("ggplot2", "mpg")
 @test isa(encoding_text_quant(:Displ, aggregate="mean"), VegaLiteVis)
 @test isa(config_mark(fontStyle="italic", fontSize=12, font="courier"), VegaLiteVis)
 
-
-
+include("test_io.jl")
 
 println("Finished")

--- a/test/test_io.jl
+++ b/test/test_io.jl
@@ -7,7 +7,7 @@ p = data_values(x = [1,2,3], y=[1,2,3]) +
     encoding_x_quant(:x) +
     encoding_y_quant(:y)
 
-Base.Filesystem.mktempdir() do folder   
+Compat.Filesystem.mktempdir() do folder   
     svg(joinpath(folder,"test1.svg"), p)
     @test isfile(joinpath(folder,"test1.svg"))
 

--- a/test/test_io.jl
+++ b/test/test_io.jl
@@ -1,4 +1,5 @@
 using Base.Test
+using Compat
 using VegaLite
 
 p = data_values(x = [1,2,3], y=[1,2,3]) +

--- a/test/test_io.jl
+++ b/test/test_io.jl
@@ -1,0 +1,34 @@
+using Base.Test
+using VegaLite
+
+p = data_values(x = [1,2,3], y=[1,2,3]) +
+    mark_point() +
+    encoding_x_quant(:x) +
+    encoding_y_quant(:y)
+
+Base.Filesystem.mktempdir() do folder   
+    svg(joinpath(folder,"test1.svg"), p)
+    @test isfile(joinpath(folder,"test1.svg"))
+
+    pdf(joinpath(folder,"test1.pdf"), p)
+    @test isfile(joinpath(folder,"test1.pdf"))
+
+    png(joinpath(folder,"test1.png"), p)
+    @test isfile(joinpath(folder,"test1.png"))
+
+    VegaLite.eps(joinpath(folder,"test1.eps"), p)
+    @test isfile(joinpath(folder,"test1.eps"))
+
+    savefig(joinpath(folder,"test2.svg"), p)
+    @test isfile(joinpath(folder,"test2.svg"))
+
+    savefig(joinpath(folder,"test2.pdf"), p)
+    @test isfile(joinpath(folder,"test2.pdf"))
+
+    savefig(joinpath(folder,"test2.png"), p)
+    @test isfile(joinpath(folder,"test2.png"))
+
+    savefig(joinpath(folder,"test2.eps"), p)
+    @test isfile(joinpath(folder,"test2.eps"))
+
+end


### PR DESCRIPTION
This is all a bit rough still, but in general this should pretty much work. This implements my suggestion in #10.

~~The PNG export looks strange right now, it seems to sometimes clip the graph. But that can probably be sorted out.~~ I also think there are more file formats supported by Cairo, so we should be able to offer even more formats using this general strategy.

~~Not ready to merge because NodeJS.jl is not yet registered.~~ Also, not clear to me whether this should be merged into ``master`` or some other process.

6/1/2017: The png problem was a mistake on my side when looking at the file, this is all working.
6/1/2017: NodeJS.jl is now registered.