### PR TITLE
Add support for the pipe operator

### DIFF
--- a/src/data_values.jl
+++ b/src/data_values.jl
@@ -6,7 +6,9 @@ data_values(*sym1*=*vec1*, *sym2*=*vec2*, ...)
 Adds data vectors (`vec1`, `vec1`,..) and binds each of them to a symbol (`sym1`, `sym2`, ...)
 """
 function data_values(;values...)
-  length(values)==0 && error("no values given")
+  if length(values)==0
+    return i->data_values(i)
+  end
 
   ks = [v[1] for v in values]
   vs = [v[2] for v in values]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -9,6 +9,10 @@ end
 +(a::VegaLiteVis, b::VegaLiteVis) = VegaLiteVis(softmerge(a.vis, b.vis))
 *(a::VegaLiteVis, b::VegaLiteVis) = VegaLiteVis(merge(a.vis, b.vis))
 
+function (a::VegaLiteVis)(b::VegaLiteVis)
+    return a + b
+end
+
 function softmerge(a::Dict, b::Dict)
     ck = intersect(keys(a), keys(b))
     nd = merge(a, b)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -9,8 +9,10 @@ end
 +(a::VegaLiteVis, b::VegaLiteVis) = VegaLiteVis(softmerge(a.vis, b.vis))
 *(a::VegaLiteVis, b::VegaLiteVis) = VegaLiteVis(merge(a.vis, b.vis))
 
-function (a::VegaLiteVis)(b::VegaLiteVis)
-    return a + b
+if VERSION>=v"0.5.0"
+    function (a::VegaLiteVis)(b::VegaLiteVis)
+        return a + b
+    end
 end
 
 function softmerge(a::Dict, b::Dict)


### PR DESCRIPTION
This enables the following syntax:
````julia
DataFrame(x=randn(200)) |> data_values() |>
    mark_bar() |>
    encoding_x_quant(:x; bin=Dict(:maxbins=>20), axis=Dict(:title=>"values")) |>
    encoding_y_quant(:*, aggregate="count", axis=Dict(:title=>"number of draws"))
````
In itself probably not a huge improvement over the existing ``+`` (although ``ggvis`` also uses pipes instead of ``+``, so there is some precedence).

But I hope to enable a dplyr like interface for [Query.jl](https://github.com/davidanthoff/Query.jl), and at that point it might make for a nice overall UI experience, i.e. one could pipe all the way from say a csv load, through some query manipulations into a plot.