### PR TITLE
Disable special case IJulia integration for now

### DIFF
--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -57,7 +57,7 @@ include("show.jl")
 include("dataframes_integration.jl")
 
 ### Integration with IJulia - Jupyter
-include("ijulia_integration.jl")
+# include("ijulia_integration.jl")
 
 ### Integration with Atom-Juno-Media
 include("atom_integration.jl")


### PR DESCRIPTION
I can't get the IJulia integration working without this. With this patch, IJulia just falls back to the new ``show`` method that sends a PNG file over to IJulia, i.e. things work.

It would of course be nicer to use the vega-lite embedding stuff, but something is broken with that.

Maybe we can merge this for now, until you or I or someone else gets the embedding stuff up and running again? I.e. just have this one here for a tagged version for juliacon, and then try to fix it.