### PR TITLE
Use TableTraits.jl for tabular data sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,9 @@
-julia 0.5
+julia 0.6
 Compat 0.9.1
 JSON
 Requires
 NodeJS
 Cairo
 Rsvg
+TableTraits 0.0.1
+IterableTables

--- a/REQUIRE
+++ b/REQUIRE
@@ -5,5 +5,6 @@ Requires
 NodeJS
 Cairo
 Rsvg
-TableTraits 0.0.1
+IteratorInterfaceExtensions 0.0.1
+TableTraits 0.0.2
 IterableTables

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
 

--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -2,12 +2,14 @@ VERSION >= v"0.4" && __precompile__()
 
 module VegaLite
 
-using JSON, Compat, Requires, NodeJS, Cairo, Rsvg
+using JSON, Compat, Requires, NodeJS, Cairo, Rsvg, TableTraits
 # using PhantomJS
 
 # import Base: show
 import Base: display, REPL.REPLDisplay
 import Base: |>
+
+import IterableTables
 
 export renderer, actionlinks, junoplotpane, png, svg, jgp, pdf, savefig
 
@@ -82,28 +84,21 @@ include("juno_integration.jl")
 include("io.jl")
 include("show.jl")
 
+### TableTraits.jl integration
+
+function vldata(d)
+    isiterabletable(d) || error("Only iterable tables can be passed to vldata.")
+
+    it = getiterator(d)
+
+    recs = [Dict(c[1]=>isnull(c[2]) ? nothing : get(c[2])  for c in zip(keys(r), values(r))) for r in it ]
+
+    VegaLite.VLSpec{:data}(Dict("values" => recs))
+end
+
+|>(a, b::VLSpec) = vldata(a) |> b
 
 ########################  conditional definitions  #######################
-
-### Integration with DataFrames
-@require DataFrames begin
-  function vldata(d::DataFrames.DataFrame)
-    recs = [ Dict(r) for r in DataFrames.eachrow(d) ]
-    VegaLite.VLSpec{:data}(Dict("values" => recs))
-  end
-
-  |>(a::DataFrames.DataFrame, b::VLSpec) = vldata(a) |> b
-end
-
-### Integration with DataTables
-@require DataTables begin
-  function vldata(d::DataTables.DataTable)
-    recs = [ Dict(r) for r in DataTables.eachrow(d) ]
-    VegaLite.VLSpec{:data}(Dict("values" => recs))
-  end
-
-  |>(a::DataTables.DataTable, b::VLSpec) = vldata(a) |> b
-end
 
 ### Integration with Juno
 include("juno_integration.jl")

--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -2,13 +2,17 @@ VERSION >= v"0.4" && __precompile__()
 
 module VegaLite
 
-using JSON, Compat, Requires, NodeJS, Cairo, Rsvg, TableTraits
+using JSON, Compat, Requires, NodeJS, Cairo, Rsvg
+import IteratorInterfaceExtensions, TableTraits
 # using PhantomJS
 
 # import Base: show
 import Base: display, REPL.REPLDisplay
 import Base: |>
 
+# This import can eventually be removed, it currently just makes sure
+# that the iterable tables integration for DataFrames and friends
+# is loaded
 import IterableTables
 
 export renderer, actionlinks, junoplotpane, png, svg, jgp, pdf, savefig
@@ -87,9 +91,9 @@ include("show.jl")
 ### TableTraits.jl integration
 
 function vldata(d)
-    isiterabletable(d) || error("Only iterable tables can be passed to vldata.")
+    TableTraits.isiterabletable(d) || error("Only iterable tables can be passed to vldata.")
 
-    it = getiterator(d)
+    it = IteratorInterfaceExtensions.getiterator(d)
 
     recs = [Dict(c[1]=>isnull(c[2]) ? nothing : get(c[2])  for c in zip(keys(r), values(r))) for r in it ]
 


### PR DESCRIPTION
This moves the iterable tables integration from [IterableTables.jl](https://github.com/davidanthoff/IterableTables.jl) into this package here. With that, any of the iterable tables source types can be piped into a vegalite graph. I also removed the special ``DataFrame`` and ``DataTable`` cases because those are also covered by the iterable tables interface.

I include a dependency on ``IterableTables`` for now, but eventually we will be able to remove that (essentially once the iterable tables integration for things like DataFrames and DataTables has been moved into those packages).

This stuff is julia 0.6 only, not sure whether that is a problem...

Oh, and things will only work with ``master`` from IterableTables.jl. If you are ok with this PR here, I'll tag a version of IterableTables and then you can merge things here.