### PR TITLE
Add .gitattribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+deps/package.json eol=lf


### PR DESCRIPTION
This makes life on Windows a little bit easier. Whenever one runs ``npm install``, it will change the line endings in ``package.json`` to lf, so on Windows that file is then marked as dirty. With this setting, the file will just always be with lf line endings and the problem is solved.