### PR TITLE
Rework data piping

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -13,3 +13,4 @@ Juno
 DataValues
 MacroTools
 NamedTuples
+URIParser

--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -8,8 +8,7 @@ import TableTraits # 0
 import FileIO # 17s !!!
 import DataValues  # 1s
 import MacroTools
-
-import Base: |>
+using URIParser
 
 # This import can eventually be removed, it currently just makes sure
 # that the iterable tables integration for DataFrames and friends

--- a/src/dsl_helper_func/dsl_helper_func.jl
+++ b/src/dsl_helper_func/dsl_helper_func.jl
@@ -107,9 +107,4 @@ function data(args...; kwargs...)
     end
 end
 
-function |>(a, b::VLSpec{:plot})
-    b.params["data"] = data(a).params
-    b
-end
-
 export data

--- a/src/vlspec.jl
+++ b/src/vlspec.jl
@@ -8,3 +8,22 @@ struct VLSpec{T}
     params::Union{Dict, Vector}
 end
 vltype(::VLSpec{T}) where T = T
+
+function (p::VLSpec{:plot})(data)
+    TableTraits.isiterabletable(data) || throw(ArgumentError("'data' is not a table."))
+
+    it = IteratorInterfaceExtensions.getiterator(data)
+    recs = [Dict(c[1]=>isa(c[2], DataValues.DataValue) ? (isnull(c[2]) ? nothing : get(c[2])) : c[2] for c in zip(keys(r), values(r))) for r in it]
+
+    new_dict = copy(p.params)
+    new_dict["data"] = Dict{String,Any}("values" => recs)
+
+    return VLSpec{:plot}(new_dict)
+end
+
+function (p::VLSpec{:plot})(uri::URI)
+    new_dict = copy(p.params)
+    new_dict["data"] = Dict{String,Any}("url" => string(uri))
+
+    return VLSpec{:plot}(new_dict)
+end


### PR DESCRIPTION
This changes how the data piping works. I believe with julia 0.7 one is encourage to no longer add methods to ``|>``. And we in fact don't need to, we can just add a method to the type itself and it does the same thing.

I also added support for piping ``URI`` instances into a plot, and then that will become the data source.