### PR TITLE
Automatically infer the type for encodings based on input data

### DIFF
--- a/src/dsl_vlplot_macro/dsl_vlplot_macro.jl
+++ b/src/dsl_vlplot_macro/dsl_vlplot_macro.jl
@@ -72,7 +72,7 @@ function fix_shortcuts(spec::Dict{String,Any}, positional_key::String)
         new_encoding_dict = Dict{String,Any}()
         for (k,v) in new_spec["encoding"]
             if v isa Symbol
-                new_encoding_dict[k] = Dict{String,Any}("field"=>string(v),"type"=>"quantitative")
+                new_encoding_dict[k] = Dict{String,Any}("field"=>string(v))
             elseif v isa String
                 new_encoding_dict[k] = Dict{String,Any}(parse_shortcut(v)...)   
             else

--- a/src/dsl_vlplot_macro/shorthandparser.jl
+++ b/src/dsl_vlplot_macro/shorthandparser.jl
@@ -86,6 +86,6 @@ function parse_shortcut(s::AbstractString)
             throw(ArgumentError("Invalid shortcut string"))
         end
     else
-        return ["field"=>tokens[1],"type"=>:quantitative]
+        return ["field"=>tokens[1]]
     end
 end

--- a/src/vlspec.jl
+++ b/src/vlspec.jl
@@ -13,10 +13,35 @@ function (p::VLSpec{:plot})(data)
     TableTraits.isiterabletable(data) || throw(ArgumentError("'data' is not a table."))
 
     it = IteratorInterfaceExtensions.getiterator(data)
+
+    col_names = TableTraits.column_names(it)
+    col_types = TableTraits.column_types(it)
+    col_type_mapping = Dict{Symbol,Type}(i[1]=>i[2] for i in zip(col_names,col_types))
+    
     recs = [Dict(c[1]=>isa(c[2], DataValues.DataValue) ? (isnull(c[2]) ? nothing : get(c[2])) : c[2] for c in zip(keys(r), values(r))) for r in it]
 
     new_dict = copy(p.params)
     new_dict["data"] = Dict{String,Any}("values" => recs)
+
+    if haskey(new_dict, "encoding")
+        for (k,v) in new_dict["encoding"]
+            if !haskey(v, "type")
+                if !haskey(v, "aggregate") && haskey(v, "field") && haskey(col_type_mapping,Symbol(v["field"]))
+                    jl_type = col_type_mapping[Symbol(v["field"])]
+                    if jl_type <: DataValues.DataValue
+                        jl_type = eltype(jl_type)
+                    end
+                    if jl_type <: Number
+                        v["type"] = "quantitative"
+                    elseif jl_type <: AbstractString
+                        v["type"] = "nominal"
+                    elseif jl_type <: Base.Dates.AbstractTime
+                        v["type"] = "temporal"
+                    end
+                end
+            end
+        end
+    end
 
     return VLSpec{:plot}(new_dict)
 end


### PR DESCRIPTION
This automatically tries to infer the type of a encoding. For example:
````julia
df = DataFrame(a=[1,2,3], b=["A", "B", "C"]

df |> @vlplot(:point, x=:a, y=:b)
````
It will then automatically add ``type="quantitative"`` to the ``a`` encoding (based on the type of the input column) and ``type="nominal"`` to the ``b`` encoding.