### PR TITLE
Export FileIO load and save function

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -8,7 +8,7 @@ Rsvg
 IteratorInterfaceExtensions 0.0.1
 TableTraits 0.0.2
 IterableTables
-FileIO
+FileIO 0.9.0
 Juno
 DataValues
 MacroTools

--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -5,7 +5,7 @@ module VegaLite
 using JSON, Compat, Requires, NodeJS, Cairo, Rsvg, NamedTuples # 6s
 import IteratorInterfaceExtensions # 1s
 import TableTraits # 0
-import FileIO # 17s !!!
+using FileIO # 17s !!!
 import DataValues  # 1s
 import MacroTools
 using URIParser
@@ -17,6 +17,7 @@ import IterableTables
 
 export renderer, actionlinks
 export png, svg, jgp, pdf, savefig, loadspec, savespec, @vl_str, @vlplot
+export load, save
 
 export mk, enc
 

--- a/src/rendering/fileio.jl
+++ b/src/rendering/fileio.jl
@@ -1,7 +1,7 @@
-function load(f::FileIO.File{FileIO.format"vegalite"})
+function fileio_load(f::FileIO.File{FileIO.format"vegalite"})
     return loadspec(f.filename)
 end
 
-function save(file::FileIO.File{FileIO.format"vegalite"}, data::VLSpec{:plot}; include_data=false)
+function fileio_save(file::FileIO.File{FileIO.format"vegalite"}, data::VLSpec{:plot}; include_data=false)
     savespec(file.filename, data, include_data=include_data)
 end


### PR DESCRIPTION
There was a recent change in FileIO.jl that now allows us to export the ``save`` and ``load`` function from FileIO.