### PR TITLE
Tweak func api

### DIFF
--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -23,6 +23,8 @@ export load, save
 
 export mk, enc
 
+export vlplot, vldata
+
 ########################  settings functions  ############################
 
 # Switch for plotting in SVGs or canvas

--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -25,6 +25,9 @@ export mk, enc
 
 export vlplot, vldata
 
+export config, selection, resolve, projection, facet, spec, rep
+export transform, hconcat, vconcat, layer
+
 ########################  settings functions  ############################
 
 # Switch for plotting in SVGs or canvas

--- a/src/dsl_helper_func/dsl_helper_func.jl
+++ b/src/dsl_helper_func/dsl_helper_func.jl
@@ -67,9 +67,7 @@ end
 #     vls
 # end
 
-plot(args...; kwargs...)        = mkSpec(:plot, args...; kwargs...)
-
-export plot
+vlplot(args...; kwargs...)        = mkSpec(:plot, args...; kwargs...)
 
 #### 1st level aliases
 
@@ -96,7 +94,7 @@ export transform, hconcat, vconcat, layer
 getrealvalue(v::DataValues.DataValue) = isnull(v) ? nothing : get(v)
 getrealvalue(v) = v
 
-function data(args...; kwargs...)
+function vldata(args...; kwargs...)
     if (length(args) == 1) && TableTraits.isiterabletable(args[1])
         it = IteratorInterfaceExtensions.getiterator(args[1])
         recs = [Dict(c[1] => getrealvalue(c[2]) for c in zip(keys(r), values(r))) for r in it]
@@ -106,5 +104,3 @@ function data(args...; kwargs...)
         mkSpec(:vldata, args...; kwargs...)
     end
 end
-
-export data

--- a/src/dsl_helper_func/dsl_helper_func.jl
+++ b/src/dsl_helper_func/dsl_helper_func.jl
@@ -84,9 +84,6 @@ hconcat(args...)   = mkSpec(:vlhconcat, args...)
 vconcat(args...)   = mkSpec(:vlvconcat, args...)
 layer(args...)     = mkSpec(:vllayer, args...)
 
-export config, selection, resolve, projection, facet, spec, rep
-export transform, hconcat, vconcat, layer
-
 ### data
 # dat is a special case, we want to interpret correctly cases where an
 # iterable table is passed as an argument


### PR DESCRIPTION
This has two sets of changes:
- It renames ``plot`` to ``vlplot``. I think we'll just run into lots of name conflicts with ``plot``. The Plots.jl package already uses that name, and then one has to qualify the name. Plus ``vlplot`` seems nice in the tradition of ``ggplot``.
- At that point I then thought that ``data`` also is a _very_ generic name, and renamed it to ``vldata``...
- I moved all the export clauses into the VegaLite.jl file. I think it is cleaner to have them all in one place so that one can see what the package actually exports.