### PR TITLE
Use png for map

### DIFF
--- a/docs/src/examples/examples_maps.md
+++ b/docs/src/examples/examples_maps.md
@@ -4,9 +4,7 @@ TODO
 
 ## One dot per zipcode in the U.S.
 
-TODO convert this to PNG output
-
-```julia
+```@example
 using VegaLite, VegaDatasets
 
 dataset("zipcodes").path |>
@@ -20,6 +18,8 @@ dataset("zipcodes").path |>
     size={value=1},
     color="digit:n"
 )
+
+VegaLite.MimeWrapper{MIME"image/png"}(dataset("zipcodes").path |> @vlplot(:circle,width=500,height=300,transform=[{calculate="substring(datum.zip_code, 0, 1)", as=:digit}],projection={typ=:albersUsa},longitude="longitude:q",latitude="latitude:q",size={value=1},color="digit:n")) # hide
 ```
 
 ## One dot per airport in the US overlayed on geoshape

--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -87,6 +87,8 @@ include("rendering/io.jl")
 include("rendering/show.jl")
 include("rendering/fileio.jl")
 
+include("mime_wrapper.jl")
+
 
 function __init__()
 

--- a/src/mime_wrapper.jl
+++ b/src/mime_wrapper.jl
@@ -1,0 +1,11 @@
+# This structure allows you to wrap a value that supports multiple MIME
+# show methods, and restrict the wrapped value to only support one. We use
+# this in the documentation in one map case to force the use of PNG as the
+# output format
+struct MimeWrapper{T}
+    source
+end
+
+function Base.show(io::IO, m::T, v::MimeWrapper{T}) where T
+    show(io, m, v.source)
+end


### PR DESCRIPTION
This is a bit weird... This specific map example creates gigantic SVG files that block browsers etc. So we really want this example to be shown as a PNG file in the documentation. The ``MimeWrapper`` type allows us to do that. It probably should be in some other repo, but I don't really know where, so for now we can just leave it here as an unexported thing.