### PR TITLE
Revert "Adapting to name change in Vega-Lite JSON schema"

### DIFF
--- a/src/schema/schema_parsing.jl
+++ b/src/schema/schema_parsing.jl
@@ -155,7 +155,7 @@ schema = JSON.parsefile(fn)
 # collect(Iterators.filter(n -> startswith(n, "TopLevel"), keys(schema["definitions"])))
 
 refs = Dict{String, SpecDef}()
-rootSpec = toDef(schema["definitions"]["TopLevelExtendedSpec"])
+rootSpec = toDef(schema["definitions"]["TopLevelSpec"])
 
 # length(refs) # 124
 # dl = rootSpec.items[2].props["layer"]


### PR DESCRIPTION
This reverts commit 15639f4d593e328e3f69f7703751ecf107ea315c.

@fredo-dedup the last commit you pushed doesn't work, the previous ``master`` had the right name there. I think you might just need to call ``Pkg.build`` on VegaLite so that you get the current schema?