### PR TITLE
Remove call to checkplot for now

### DIFF
--- a/src/rendering/render.jl
+++ b/src/rendering/render.jl
@@ -201,7 +201,7 @@ end
 
 
 function Base.display(d::Base.REPL.REPLDisplay, plt::VLSpec{:plot})
-  checkplot(plt)
+  # checkplot(plt)
   tmppath = writehtml_full(JSON.json(plt.params))
   launch_browser(tmppath) # Open the browser
 end


### PR DESCRIPTION
Right now this prevents viewing of legitimate plots. The proper fix is of course to fix ``checkplot`` to not throw an error, but for now it seems easier to just disable that call.