### PR TITLE
Remove some exported functions that clash with other packages

### DIFF
--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -18,7 +18,7 @@ using Random
 import IterableTables
 
 export renderer, actionlinks
-export png, svg, jgp, pdf, savefig, loadspec, savespec, @vl_str, @vlplot
+export @vl_str, @vlplot
 export @vg_str
 export load, save
 

--- a/test/test_io.jl
+++ b/test/test_io.jl
@@ -9,28 +9,28 @@ p = DataFrame(x = [1,2,3], y=[1,2,3]) |> @vlplot(:point, x="x:q", y="y:q")
 vgp = getvgplot()
 
 Base.Filesystem.mktempdir() do folder
-    svg(joinpath(folder,"test1.svg"), p)
+    VegaLite.svg(joinpath(folder,"test1.svg"), p)
     @test isfile(joinpath(folder,"test1.svg"))
 
-    pdf(joinpath(folder,"test1.pdf"), p)
+    VegaLite.pdf(joinpath(folder,"test1.pdf"), p)
     @test isfile(joinpath(folder,"test1.pdf"))
 
-    png(joinpath(folder,"test1.png"), p)
+    VegaLite.png(joinpath(folder,"test1.png"), p)
     @test isfile(joinpath(folder,"test1.png"))
 
     VegaLite.eps(joinpath(folder,"test1.eps"), p)
     @test isfile(joinpath(folder,"test1.eps"))
 
-    savefig(joinpath(folder,"test2.svg"), p)
+    VegaLite.savefig(joinpath(folder,"test2.svg"), p)
     @test isfile(joinpath(folder,"test2.svg"))
 
-    savefig(joinpath(folder,"test2.pdf"), p)
+    VegaLite.savefig(joinpath(folder,"test2.pdf"), p)
     @test isfile(joinpath(folder,"test2.pdf"))
 
-    savefig(joinpath(folder,"test2.png"), p)
+    VegaLite.savefig(joinpath(folder,"test2.png"), p)
     @test isfile(joinpath(folder,"test2.png"))
 
-    savefig(joinpath(folder,"test2.eps"), p)
+    VegaLite.savefig(joinpath(folder,"test2.eps"), p)
     @test isfile(joinpath(folder,"test2.eps"))
 
     save(joinpath(folder,"test2.svg"), p)


### PR DESCRIPTION
This would make issues like https://github.com/JuliaPlots/Plots.jl/issues/1736 go away.

I also think we don't need them, because folks can use ``load`` and ``save``, which we reexport from FileIO.jl, so they can be nicely shared between lots of different packages.

@fredo-dedup I don't want to merge this without your approval, though.