### PR TITLE
Enhancement request: deletedata[!] function

### DIFF
--- a/src/VegaLite.jl
+++ b/src/VegaLite.jl
@@ -22,6 +22,7 @@ export renderer, actionlinks
 export @vl_str, @vlplot
 export @vg_str
 export load, save
+export deletedata, deletedata!
 
 export mk, enc
 

--- a/src/vgspec.jl
+++ b/src/vgspec.jl
@@ -3,3 +3,4 @@ struct VGSpec <: AbstractVegaSpec
 end
 
 Base.:(==)(x::VGSpec, y::VGSpec) = x.params == y.params
+Base.copy(spec::VGSpec) = VGSpec(copy(spec))

--- a/src/vgspec.jl
+++ b/src/vgspec.jl
@@ -1,3 +1,5 @@
 struct VGSpec <: AbstractVegaSpec
     params::Union{Dict, Vector}
 end
+
+Base.:(==)(x::VGSpec, y::VGSpec) = x.params == y.params

--- a/src/vlspec.jl
+++ b/src/vlspec.jl
@@ -70,3 +70,5 @@ function (p::VLSpec{:plot})(path::AbstractPath)
 
     return VLSpec{:plot}(new_dict)
 end
+
+Base.:(==)(x::VLSpec, y::VLSpec) = vltype(x) == vltype(y) && x.params == y.params

--- a/src/vlspec.jl
+++ b/src/vlspec.jl
@@ -73,3 +73,20 @@ end
 
 Base.:(==)(x::VLSpec, y::VLSpec) = vltype(x) == vltype(y) && x.params == y.params
 Base.copy(spec::T) where {T <: VLSpec} = T(copy(spec.params))
+
+"""
+    deletedata!(spec::VLSpec)
+
+Delete data from `spec` in-place.  See also [`deletedata`](@ref).
+"""
+function deletedata!(spec::VLSpec)
+    delete!(spec.params, "data")
+    return spec
+end
+
+"""
+    deletedata(spec::VLSpec)
+
+Create a copy of `spec` without data.  See also [`deletedata!`](@ref).
+"""
+deletedata(spec::VLSpec) = deletedata!(copy(spec))

--- a/src/vlspec.jl
+++ b/src/vlspec.jl
@@ -72,3 +72,4 @@ function (p::VLSpec{:plot})(path::AbstractPath)
 end
 
 Base.:(==)(x::VLSpec, y::VLSpec) = vltype(x) == vltype(y) && x.params == y.params
+Base.copy(spec::T) where {T <: VLSpec} = T(copy(spec.params))

--- a/test/test_io.jl
+++ b/test/test_io.jl
@@ -77,7 +77,7 @@ Base.Filesystem.mktempdir() do folder
 
     vgpl2 = VegaLite.loadvgspec(joinpath(folder,"test1.vega"))
 
-    @test vgpl1.params == vgpl1.params
+    @test vgpl1 == vgpl1
 
     # TODO Enable once FileIO stuff is merged
     # save(joinpath(folder,"test3.vega"), vgpl1)

--- a/test/test_spec.jl
+++ b/test/test_spec.jl
@@ -7,13 +7,13 @@ using VegaDatasets
 
 @testset "Spec" begin
 
-@test @vlplot()(URI("http://www.foo.com/bar.json")).params == vl"""
+@test @vlplot()(URI("http://www.foo.com/bar.json")) == vl"""
     {
         "data": {
             "url": "http://www.foo.com/bar.json"
         }
     }
-    """.params
+    """
 
 @test_throws ArgumentError @vlplot()(5)
 
@@ -42,7 +42,7 @@ p2 = vl"""
 
 delete!(p1.params, "data")
 
-@test p1.params == p2.params
+@test p1 == p2
 
 p3 = DataFrame(a=[1,2,missing], b=[3.,2.,1.]) |> @vlplot(:point, x=:a, y=:b)
 
@@ -78,7 +78,7 @@ p4 = vl"""
 }
 """
 
-# @test p3.params == p4.params
+# @test p3 == p4
 
 p5 = dataset("cars").path |> @vlplot(:point, x=:Miles_per_Gallon, y=:Acceleration)
 

--- a/test/test_spec.jl
+++ b/test/test_spec.jl
@@ -40,7 +40,11 @@ p2 = vl"""
 }
 """
 
-delete!(p1.params, "data")
+p3 = deletedata(p1)
+@test p3 != p1
+@test p3 == p2
+
+deletedata!(p1)
 
 @test p1 == p2
 

--- a/test/test_vlplot_macro.jl
+++ b/test/test_vlplot_macro.jl
@@ -6,27 +6,27 @@ using Test
 
 @testset "@vlplot macro" begin
 
-@test @vlplot(mark={"point"}).params == (vl"""
+@test @vlplot(mark={"point"}) == (vl"""
     {"mark": {"type": "point"}}
-    """).params
+    """)
 
-@test @vlplot("point", data={values=[{a=1}]}).params == (vl"""
+@test @vlplot("point", data={values=[{a=1}]}) == (vl"""
     {"mark": "point", "data": {"values":[{"a": 1}]}}
-""").params
+""")
 
-@test @vlplot(:point, x=:foo).params == @vlplot(:point, enc={x=:foo}).params
+@test @vlplot(:point, x=:foo) == @vlplot(:point, enc={x=:foo})
 
-@test @vlplot(mark={typ=:point}).params == @vlplot(mark={:point}).params
+@test @vlplot(mark={typ=:point}) == @vlplot(mark={:point})
 
-@test (p"/foo/bar" |> @vlplot(:point)).params == @vlplot(:point, data=p"/foo/bar").params
+@test (p"/foo/bar" |> @vlplot(:point)) == @vlplot(:point, data=p"/foo/bar")
 
-@test (p"/foo/bar" |> @vlplot(:point)).params == @vlplot(:point, data={url=p"/foo/bar"}).params
+@test (p"/foo/bar" |> @vlplot(:point)) == @vlplot(:point, data={url=p"/foo/bar"})
 
-@test (URI("http://foo.com/bar.json") |> @vlplot(:point)).params == @vlplot(:point, data=URI("http://foo.com/bar.json")).params
+@test (URI("http://foo.com/bar.json") |> @vlplot(:point)) == @vlplot(:point, data=URI("http://foo.com/bar.json"))
 
-@test (URI("http://foo.com/bar.json") |> @vlplot(:point)).params == @vlplot(:point, data={url=URI("http://foo.com/bar.json")}).params
+@test (URI("http://foo.com/bar.json") |> @vlplot(:point)) == @vlplot(:point, data={url=URI("http://foo.com/bar.json")})
 
-@test (DataFrame(a=[1]) |> @vlplot(:point)).params == @vlplot(:point, data=DataFrame(a=[1])).params
+@test (DataFrame(a=[1]) |> @vlplot(:point)) == @vlplot(:point, data=DataFrame(a=[1]))
 
 @test @vlplot("point", transform=[{lookup="foo", from={data=p"/foo/bar", key="bar"}}]).params["transform"][1]["from"]["data"]["url"] == (Sys.iswindows() ? "file://foo/bar" : "file:///foo/bar")
 @test @vlplot("point", transform=[{lookup="foo", from={data={url=p"/foo/bar"}, key="bar"}}]).params["transform"][1]["from"]["data"]["url"] == (Sys.iswindows() ? "file://foo/bar" : "file:///foo/bar")
@@ -35,7 +35,7 @@ using Test
 
 @test @vlplot("point", transform=[{lookup="foo", from={data=DataFrame(a=[1]), key="bar"}}]).params["transform"][1]["from"]["data"]["values"][1]["a"] == 1
 
-@test [@vlplot("point") @vlplot("circle")].params == (vl"""
+@test [@vlplot("point") @vlplot("circle")] == (vl"""
 {
     "hconcat": [
         {
@@ -46,9 +46,9 @@ using Test
         }
     ]
 }
-""").params
+""")
 
-@test [@vlplot("point"); @vlplot("circle")].params == (vl"""
+@test [@vlplot("point"); @vlplot("circle")] == (vl"""
 {
     "vconcat": [
         {
@@ -59,9 +59,9 @@ using Test
         }
     ]
 }
-""").params
+""")
 
-@test @vlplot("point", x={"foo:q"}).params == (vl"""
+@test @vlplot("point", x={"foo:q"}) == (vl"""
 {
     "mark": "point",
     "encoding": {
@@ -71,18 +71,18 @@ using Test
         }
     }
 }
-""").params
+""")
 
-@test (@vlplot(description="foo") + @vlplot(:point) + @vlplot(:circle)).params == @vlplot(description="foo", layer=[{mark=:point},{mark=:circle}]).params
+@test (@vlplot(description="foo") + @vlplot(:point) + @vlplot(:circle)) == @vlplot(description="foo", layer=[{mark=:point},{mark=:circle}])
 
-@test (@vlplot(facet={row={field=:foo, typ=:bar}}) + @vlplot(:point)).params == @vlplot(facet={row={field=:foo, typ=:bar}}, spec={mark=:point}).params
+@test (@vlplot(facet={row={field=:foo, typ=:bar}}) + @vlplot(:point)) == @vlplot(facet={row={field=:foo, typ=:bar}}, spec={mark=:point})
 
-@test (@vlplot(repeat={column=[:foo, :bar]}) + @vlplot(:point)).params == @vlplot(repeat={column=[:foo, :bar]}, spec={mark=:point}).params
+@test (@vlplot(repeat={column=[:foo, :bar]}) + @vlplot(:point)) == @vlplot(repeat={column=[:foo, :bar]}, spec={mark=:point})
 
-@test (@vlplot(description="foo") + [@vlplot(:point) @vlplot(:circle)]).params == @vlplot(description="foo", hconcat=[{mark=:point},{mark=:circle}]).params
+@test (@vlplot(description="foo") + [@vlplot(:point) @vlplot(:circle)]) == @vlplot(description="foo", hconcat=[{mark=:point},{mark=:circle}])
 
-@test (@vlplot(description="foo") + [@vlplot(:point); @vlplot(:circle)]).params == @vlplot(description="foo", vconcat=[{mark=:point},{mark=:circle}]).params
+@test (@vlplot(description="foo") + [@vlplot(:point); @vlplot(:circle)]) == @vlplot(description="foo", vconcat=[{mark=:point},{mark=:circle}])
 
-@test (@vlplot(:point, x=:a)(DataFrame(a=[1])).params == @vlplot(:point, data=DataFrame(a=[1]), x=:a).params)
+@test (@vlplot(:point, x=:a)(DataFrame(a=[1])) == @vlplot(:point, data=DataFrame(a=[1]), x=:a))
 
 end


### PR DESCRIPTION
The first two commits implements `Base.==` and `Base.copy` for the spec types.  The last commit adds functions

```julia
deletedata!(spec::VLSpec) = (delete!(spec.params, "data"); spec)
deletedata(spec::VLSpec) = deletedata!(copy(spec))
```

`Base.copy` is used in `deletedata!` and `Base.==` is used in the tests.

`deletedata[!]` would be useful with the Julia code printer introduced in #162.
